### PR TITLE
Add placeholder eToro tools page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Because this fetch happens from the browser, cross‑origin restrictions may pre
 ## Note
 
 An internet connection is required for the investor list to load. If the request to eToro is blocked, the page will display an error message.
+
+## eToro Tools
+
+The repository also includes a placeholder page `etoro.html` for future tools.
+Planned features include importing a profile from JSON and exporting data to CSV.

--- a/etoro.html
+++ b/etoro.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>eToro Tools</title>
+</head>
+<body>
+    <h1>eToro Tools</h1>
+    <p>This page will host utilities for eToro users.</p>
+    <p>Planned features include importing a profile in JSON format and exporting data to CSV.</p>
+    <p>Functionality will be implemented in future updates.</p>
+    <p><a href="index.html">Back to Investor List</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 </head>
 <body>
     <h1>Popular eToro Investors</h1>
+    <p><a href="etoro.html">eToro Tools</a></p>
     <p>The list below is fetched directly from the eToro Discover People page using client-side JavaScript.</p>
     <div id="investor-list">
         <!-- investor list will appear here automatically -->


### PR DESCRIPTION
## Summary
- add `etoro.html` placeholder page describing upcoming JSON import and CSV export features
- link to new page from homepage
- document the tools page in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fc37d1654832b93029b5aa74a8bd3