### PR TITLE
Add ranking API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # eToro Popular Investors List
 
-This repository provides a simple web page that fetches the list of popular investors directly from [eToro Discover People](https://www.etoro.com/discover/people) using client-side JavaScript.
+This repository provides a simple web page that fetches:
+
+* The list of popular investors directly from [eToro Discover People](https://www.etoro.com/discover/people).
+* The ranking results for a specific user using the eToro rankings API.
 
 ## Usage
 
-Open `index.html` in a browser. The page will attempt to download the HTML of the eToro Discover People page and parse the investor links. The names and links will then appear on the page automatically.
+Open `index.html` in a browser. The page will attempt to download the HTML of the eToro Discover People page and parse the investor links. It also calls the rankings API to show the historical ranking for a specific user. The names, links and ranking data will then appear on the page automatically.
 
 Because this fetch happens from the browser, cross‑origin restrictions may prevent the request from succeeding. If you see a CORS error, you may need to serve the page from a local server or use a CORS proxy.
 
 ## Note
 
-An internet connection is required for the investor list to load. If the request to eToro is blocked, the page will display an error message.
+An internet connection is required for the investor list and ranking data to load. If the requests to eToro are blocked, the page will display an error message.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>Popular eToro Investors</title>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
-        const container = document.getElementById('investor-list');
+        const investorContainer = document.getElementById('investor-list');
+        const rankingsContainer = document.getElementById('rankings');
+
         fetch('https://www.etoro.com/discover/people')
             .then(resp => resp.text())
             .then(html => {
@@ -27,10 +29,19 @@
                     li.appendChild(link);
                     ul.appendChild(li);
                 });
-                container.appendChild(ul);
+                investorContainer.appendChild(ul);
             })
             .catch(err => {
-                container.textContent = 'Failed to load investor list: ' + err;
+                investorContainer.textContent = 'Failed to load investor list: ' + err;
+            });
+
+        fetch('https://www.etoro.com/sapi/rankings/cid/7659559/rankings/?Period=LastTwoYears')
+            .then(resp => resp.json())
+            .then(data => {
+                rankingsContainer.textContent = JSON.stringify(data, null, 2);
+            })
+            .catch(err => {
+                rankingsContainer.textContent = 'Failed to load rankings: ' + err;
             });
     });
     </script>
@@ -41,5 +52,9 @@
     <div id="investor-list">
         <!-- investor list will appear here automatically -->
     </div>
+    <h2>Ranking Results</h2>
+    <pre id="rankings">
+        <!-- ranking data will appear here automatically -->
+    </pre>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch eToro ranking data for a specific user and display it on the page
- document the new API usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d6b68da78832b9a5f5981bc159967