### PR TITLE
Add JSON portfolio processing tool

### DIFF
--- a/etoro.html
+++ b/etoro.html
@@ -7,9 +7,74 @@
 </head>
 <body>
     <h1>eToro Tools</h1>
-    <p>This page will host utilities for eToro users.</p>
-    <p>Planned features include importing a profile in JSON format and exporting data to CSV.</p>
-    <p>Functionality will be implemented in future updates.</p>
+    <p>Paste your eToro API JSON below and click "Process JSON" to generate a table of positions.</p>
+
+    <h2>Import Portfolio JSON</h2>
+    <textarea id="json-input" rows="10" cols="80" placeholder="Paste eToro API response here"></textarea><br>
+    <button id="process-btn">Process JSON</button>
+
+    <div id="result"></div>
+
     <p><a href="index.html">Back to Investor List</a></p>
+
+    <script>
+    document.getElementById('process-btn').addEventListener('click', function () {
+        const input = document.getElementById('json-input').value;
+        let data;
+        try {
+            data = JSON.parse(input);
+        } catch (e) {
+            alert('Invalid JSON: ' + e.message);
+            return;
+        }
+
+        let positions;
+        try {
+            positions = data.AggregatedResult.ApiResponses.PrivatePortfolio.Content.ClientPortfolio.Positions;
+            if (!Array.isArray(positions)) throw new Error('Positions not found');
+        } catch (e) {
+            alert('Could not locate positions in JSON');
+            return;
+        }
+
+        const resultDiv = document.getElementById('result');
+        resultDiv.innerHTML = '';
+
+        const table = document.createElement('table');
+        const header = document.createElement('tr');
+        ['InstrumentID', 'Quantity', 'Cost', 'Date'].forEach(col => {
+            const th = document.createElement('th');
+            th.textContent = col;
+            header.appendChild(th);
+        });
+        table.appendChild(header);
+
+        positions.forEach(pos => {
+            const tr = document.createElement('tr');
+            const d = new Date(pos.OpenDateTime);
+            const month = ('0' + (d.getMonth() + 1)).slice(-2);
+            const day = ('0' + d.getDate()).slice(-2);
+            const year = d.getFullYear();
+            const mmdd = `${month}/${day}/${year}`;
+            const iso = `${year}-${month}-${day}`;
+
+            const values = [
+                pos.InstrumentID,
+                pos.Units,
+                pos.Amount,
+                `${mmdd} (${iso})`
+            ];
+
+            values.forEach(v => {
+                const td = document.createElement('td');
+                td.textContent = v;
+                tr.appendChild(td);
+            });
+            table.appendChild(tr);
+        });
+
+        resultDiv.appendChild(table);
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand `etoro.html` to allow pasting a JSON response from the eToro API
- add processing script that builds a table of positions showing InstrumentID, quantity, cost, and formatted date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd1654324832bbb887a20174b6fff