### PR TITLE
Sort positions by total cost

### DIFF
--- a/etoro.html
+++ b/etoro.html
@@ -69,6 +69,9 @@
         });
         table.appendChild(header);
 
+        // Sort positions by total cost (OpenRate * Units) descending
+        positions.sort((a, b) => (b.OpenRate * b.Units) - (a.OpenRate * a.Units));
+
         positions.forEach(pos => {
             const tr = document.createElement('tr');
             const d = new Date(pos.OpenDateTime);


### PR DESCRIPTION
## Summary
- sort the positions table by `OpenRate * Units`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd465ac14832ba480db4d6e993dbb