### PR TITLE
Add simple habit tracker

### DIFF
--- a/habit-tracker/habits.js
+++ b/habit-tracker/habits.js
@@ -1,0 +1,47 @@
+(function() {
+    const form = document.getElementById('habit-form');
+    const input = document.getElementById('habit-input');
+    const list = document.getElementById('habit-list');
+
+    let habits = [];
+
+    function saveHabits() {
+        localStorage.setItem('habits', JSON.stringify(habits));
+    }
+
+    function addHabit(name) {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = name;
+        list.appendChild(li);
+    }
+
+    function loadHabits() {
+        const stored = localStorage.getItem('habits');
+        if (stored) {
+            try {
+                habits = JSON.parse(stored);
+                habits.forEach(addHabit);
+            } catch(e) {
+                console.error('Failed to parse habits from localStorage');
+            }
+        }
+    }
+
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const name = input.value.trim();
+        if (!name) return;
+        const exists = habits.some(h => h.toLowerCase() === name.toLowerCase());
+        if (exists) {
+            alert('Habit with this name already exists');
+            return;
+        }
+        habits.push(name);
+        addHabit(name);
+        saveHabits();
+        input.value = '';
+    });
+
+    loadHabits();
+})();

--- a/habit-tracker/index.html
+++ b/habit-tracker/index.html
@@ -3,26 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Popular eToro Investors</title>
+    <title>Habit Tracker</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="../index.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="habits.js"></script>
+    <script defer src="habits.js"></script>
 </head>
 <body class="bg-light">
     <div class="container py-4">
         <h1 class="text-center mb-3">Habit Tracker</h1>
-        <p>Track your habits and see how they're doing.</p>
-        <p>This is a simple tool that allows you to track your habits and see how they're doing.</p>
-        <p>The data is stored in a JSON file in the browser's local storage. You can clear the data by clicking the "Clear Data" button.</p>
-        <p>If you change your browser, the data will be lost.</p>
-        
-        <div class="container text-center">
-            <div class="row">
-              <div class="col-sm-8">
-               
-              </div>
-            </div>
+        <form id="habit-form" class="input-group mb-3">
+            <input type="text" id="habit-input" class="form-control" placeholder="New habit" required>
+            <button class="btn btn-primary" type="submit">Add Habit</button>
+        </form>
+        <ul id="habit-list" class="list-group"></ul>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build a new Habit Tracker page
- implement JavaScript to store unique habits in localStorage and restore them

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687356fad8c0832b8074798d4f471a25