### PR TITLE
Add habit deletion and clear storage controls

### DIFF
--- a/habit-tracker/habits.js
+++ b/habit-tracker/habits.js
@@ -11,8 +11,18 @@
 
     function addHabit(name) {
         const li = document.createElement('li');
-        li.className = 'list-group-item';
-        li.textContent = name;
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.dataset.name = name;
+
+        const span = document.createElement('span');
+        span.textContent = name;
+        li.appendChild(span);
+
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-sm btn-danger remove-habit';
+        btn.textContent = 'Remove';
+        li.appendChild(btn);
+
         list.appendChild(li);
     }
 
@@ -41,6 +51,28 @@
         addHabit(name);
         saveHabits();
         input.value = '';
+    });
+
+    list.addEventListener('click', function(e) {
+        if (e.target.classList.contains('remove-habit')) {
+            const li = e.target.closest('li');
+            const name = li.dataset.name;
+            const confirmDelete = confirm(`Delete habit "${name}"?`);
+            if (confirmDelete) {
+                habits = habits.filter(h => h !== name);
+                li.remove();
+                saveHabits();
+            }
+        }
+    });
+
+    document.getElementById('clear-storage').addEventListener('click', function() {
+        const msg = 'This will permanently delete all your habits and cannot be undone. Continue?';
+        if (confirm(msg)) {
+            localStorage.removeItem('habits');
+            habits = [];
+            list.innerHTML = '';
+        }
     });
 
     loadHabits();

--- a/habit-tracker/index.html
+++ b/habit-tracker/index.html
@@ -18,6 +18,7 @@
             <button class="btn btn-primary" type="submit">Add Habit</button>
         </form>
         <ul id="habit-list" class="list-group"></ul>
+        <button id="clear-storage" class="btn btn-danger mt-3">Clear All Data</button>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable deleting individual habits with confirmation
- add a red **Clear All Data** button that wipes local storage

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68735ae0fcb4832b93e6872aaddaff49