### PR TITLE
Add edit mode toggle to habit tracker

### DIFF
--- a/habit-tracker/habits.js
+++ b/habit-tracker/habits.js
@@ -2,6 +2,16 @@
     const form = document.getElementById('habit-form');
     const input = document.getElementById('habit-input');
     const list = document.getElementById('habit-list');
+    const toggleEdit = document.getElementById('toggle-edit');
+
+    let editMode = false;
+
+    function updateEditVisibility() {
+        toggleEdit.textContent = editMode ? 'Done' : 'Edit Mode';
+        document.querySelectorAll('.edit-only').forEach(el => {
+            el.classList.toggle('d-none', !editMode);
+        });
+    }
 
     let habits = [];
 
@@ -50,12 +60,12 @@
         btnGroup.appendChild(trackBtn);
 
         const goalBtn = document.createElement('button');
-        goalBtn.className = 'btn btn-sm btn-outline-primary me-2 set-goal';
+        goalBtn.className = 'btn btn-sm btn-outline-primary me-2 set-goal edit-only';
         goalBtn.textContent = 'Goal';
         btnGroup.appendChild(goalBtn);
 
         const removeBtn = document.createElement('button');
-        removeBtn.className = 'btn btn-sm btn-danger remove-habit';
+        removeBtn.className = 'btn btn-sm btn-danger remove-habit edit-only';
         removeBtn.textContent = 'Remove';
         btnGroup.appendChild(removeBtn);
 
@@ -114,6 +124,7 @@
 
         list.appendChild(li);
         updateHabitDisplay(li, habit);
+        updateEditVisibility();
     }
 
     function formatHistoryDate(ts) {
@@ -182,13 +193,13 @@
             const btnWrap = document.createElement('div');
 
             const editBtn = document.createElement('button');
-            editBtn.className = 'btn btn-sm btn-outline-secondary me-1 edit-entry';
+            editBtn.className = 'btn btn-sm btn-outline-secondary me-1 edit-entry edit-only';
             editBtn.textContent = 'Edit';
             editBtn.dataset.ts = ts;
             btnWrap.appendChild(editBtn);
 
             const removeBtn = document.createElement('button');
-            removeBtn.className = 'btn btn-sm btn-outline-danger remove-entry';
+            removeBtn.className = 'btn btn-sm btn-outline-danger remove-entry edit-only';
             removeBtn.textContent = 'Remove';
             removeBtn.dataset.ts = ts;
             btnWrap.appendChild(removeBtn);
@@ -203,6 +214,7 @@
         } else {
             loadMoreBtn.style.display = 'none';
         }
+        updateEditVisibility();
     }
 
     function loadHabits() {
@@ -314,5 +326,11 @@
         }
     });
 
+    toggleEdit.addEventListener('click', function() {
+        editMode = !editMode;
+        updateEditVisibility();
+    });
+
     loadHabits();
+    updateEditVisibility();
 })();

--- a/habit-tracker/index.html
+++ b/habit-tracker/index.html
@@ -13,12 +13,15 @@
 <body class="bg-light">
     <div class="container py-4">
         <h1 class="text-center mb-3">Habit Tracker</h1>
-        <form id="habit-form" class="input-group mb-3">
+        <div class="text-center mb-3">
+            <button id="toggle-edit" class="btn btn-secondary">Edit Mode</button>
+        </div>
+        <form id="habit-form" class="input-group mb-3 edit-only">
             <input type="text" id="habit-input" class="form-control" placeholder="New habit" required>
             <button class="btn btn-primary" type="submit">Add Habit</button>
         </form>
         <ul id="habit-list" class="list-group"></ul>
-        <button id="clear-storage" class="btn btn-danger mt-3">Clear All Data</button>
+        <button id="clear-storage" class="btn btn-danger mt-3 edit-only">Clear All Data</button>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Edit Mode button
- hide edit-related controls until Edit Mode is enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68736d845bd8832b912832e58ca49d45